### PR TITLE
GL debug output in guacamole

### DIFF
--- a/include/gua/renderer/Window.hpp
+++ b/include/gua/renderer/Window.hpp
@@ -79,6 +79,7 @@ class GUA_DLL Window {
     GUA_ADD_PROPERTY(math::vec2ui, right_resolution, math::vec2ui(800, 600));
     GUA_ADD_PROPERTY(math::vec2ui, right_position, math::vec2ui(0, 0));
     GUA_ADD_PROPERTY(bool, enable_vsync, true);
+    GUA_ADD_PROPERTY(bool, debug, false);
     GUA_ADD_PROPERTY(std::string, warp_matrix_red_right, "");
     GUA_ADD_PROPERTY(std::string, warp_matrix_green_right, "");
     GUA_ADD_PROPERTY(std::string, warp_matrix_blue_right, "");
@@ -152,6 +153,14 @@ class GUA_DLL Window {
   RenderContext* get_context();
 
 protected:
+  
+  struct DebugOutput : public scm::gl::render_context::debug_output {
+    /*virtual*/ void operator()(scm::gl::debug_source source, 
+                                scm::gl::debug_type type, 
+                                scm::gl::debug_severity severity, 
+                                const std::string& message) const;
+  };
+
   ShaderProgram fullscreen_shader_;
   scm::gl::quad_geometry_ptr fullscreen_quad_;
 

--- a/src/gua/renderer/Window.cpp
+++ b/src/gua/renderer/Window.cpp
@@ -98,7 +98,7 @@ void Window::open() {
       scm::gl::FORMAT_RGBA_8, scm::gl::FORMAT_D24_S8, true, false);
 
   scm::gl::wm::context::attribute_desc context_attribs(
-      4, 3, false, false, false);
+      4, 3, false, config.get_debug(), false);
 
   ctx_.display =
       scm::gl::wm::display_ptr(new scm::gl::wm::display(config.get_display_name()));
@@ -135,6 +135,9 @@ void Window::open() {
                                                         scm::gl::FUNC_ONE,
                                                         scm::gl::FUNC_ONE,
                                                         scm::gl::FUNC_ONE);
+  if (config.get_debug()) {
+    ctx_.render_context->register_debug_callback(boost::make_shared<DebugOutput>());
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -299,5 +302,17 @@ void Window::display(std::shared_ptr<Texture2D> const& texture,
 
 ////////////////////////////////////////////////////////////////////////////////
 
+void Window::DebugOutput::operator()(scm::gl::debug_source source, 
+                                     scm::gl::debug_type type, 
+                                     scm::gl::debug_severity severity, 
+                                     const std::string& message) const {
+
+  Logger::LOG_MESSAGE << "[Source: " << scm::gl::debug_source_string(source)
+                      << ", type: " << scm::gl::debug_type_string(type)
+                      << ", severity: " << scm::gl::debug_severity_string(severity)
+                      << "]: " << message << std::endl;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 
 }


### PR DESCRIPTION
This pull request makes it possible to obtain debug information from the OpenGL runtime.

Debug output can be enabled by setting 'debug' property of gua::Window to true. GL events will then be printed in the terminal.
