### PR TITLE
Allow cursor mode to be set at any time, even before window is opened

### DIFF
--- a/src/gua/renderer/GlfwWindow.cpp
+++ b/src/gua/renderer/GlfwWindow.cpp
@@ -143,7 +143,17 @@ void GlfwWindow::open() {
   glfwSetScrollCallback(      glfw_window_, &on_window_scroll);
   glfwSetCursorEnterCallback( glfw_window_, &on_window_enter);
 
-  glfwSetInputMode(glfw_window_, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
+  switch(cursor_mode_) { 
+    case CursorMode::NORMAL:
+     glfwSetInputMode(glfw_window_, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
+    break;
+    case CursorMode::HIDDEN:
+     glfwSetInputMode(glfw_window_, GLFW_CURSOR, GLFW_CURSOR_HIDDEN);
+    break;
+    case CursorMode::DISABLED:
+     glfwSetInputMode(glfw_window_, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
+    break;
+  }
 
   if (!glfw_window_) {
     Logger::LOG_WARNING << "Failed to open GlfwWindow: Could not create glfw3 window!" << std::endl;
@@ -182,18 +192,19 @@ void GlfwWindow::process_events() {
 ////////////////////////////////////////////////////////////////////////////////
 
 void GlfwWindow::cursor_mode(CursorMode mode) {
+  
   switch(mode) { 
     case CursorMode::NORMAL:
-     glfwSetInputMode(glfw_window_, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
-     cursor_mode_ = CursorMode::NORMAL;
+      if(get_is_open()) glfwSetInputMode(glfw_window_, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
+      cursor_mode_ = mode;
     break;
     case CursorMode::HIDDEN:
-     glfwSetInputMode(glfw_window_, GLFW_CURSOR, GLFW_CURSOR_HIDDEN);
-     cursor_mode_ = CursorMode::HIDDEN;
+      if(get_is_open()) glfwSetInputMode(glfw_window_, GLFW_CURSOR, GLFW_CURSOR_HIDDEN);
+      cursor_mode_ = mode;
     break;
     case CursorMode::DISABLED:
-     glfwSetInputMode(glfw_window_, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
-     cursor_mode_ = CursorMode::DISABLED;
+      if(get_is_open()) glfwSetInputMode(glfw_window_, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
+      cursor_mode_ = mode;
     break;
     default:
       Logger::LOG_WARNING << "Cursor mode undefined or unsupported" << std::endl; break;


### PR DESCRIPTION
Previously setting the cursor mode in avango before viewer.run() crashed. 