### PR TITLE
Thinner attribute textures & SS Reconstruction

### DIFF
--- a/plugins/guacamole-plod/include/gua/renderer/PLODRenderer.hpp
+++ b/plugins/guacamole-plod/include/gua/renderer/PLODRenderer.hpp
@@ -46,7 +46,7 @@ namespace gua {
 
     PLODRenderer();
 
-    void render(Pipeline& pipe, PipelinePassDescription const& desc);
+    void render(Pipeline& pipe, PipelinePassDescription const& desc, bool rendering_shadows);
     void set_global_substitution_map(SubstitutionMap const& smap) { global_substitution_map_ = smap; }
   
     void reload_programs();

--- a/plugins/guacamole-plod/include/gua/renderer/PLODRenderer.hpp
+++ b/plugins/guacamole-plod/include/gua/renderer/PLODRenderer.hpp
@@ -90,6 +90,7 @@ namespace gua {
     scm::gl::texture_2d_ptr                      accumulation_pass_color_result_;
     scm::gl::texture_2d_ptr                      accumulation_pass_normal_result_;
     scm::gl::texture_2d_ptr                      accumulation_pass_pbr_result_;
+    scm::gl::texture_2d_ptr                      accumulation_pass_weight_and_depth_result_;
     scm::gl::frame_buffer_ptr                    accumulation_pass_result_fbo_;
 
     //normalization pass FBO & attachments

--- a/plugins/guacamole-plod/resources/shaders/gbuffer/plod/p02_accumulation.frag
+++ b/plugins/guacamole-plod/resources/shaders/gbuffer/plod/p02_accumulation.frag
@@ -32,9 +32,10 @@ layout(binding=0) uniform sampler2D p01_linear_depth_texture;
 // output
 ///////////////////////////////////////////////////////////////////////////////
 
-layout (location = 0) out vec4 out_accumulated_color;
-layout (location = 1) out vec4 out_accumulated_normal;
+layout (location = 0) out vec3 out_accumulated_color;
+layout (location = 1) out vec3 out_accumulated_normal;
 layout (location = 2) out vec3 out_accumulated_pbr;
+layout (location = 3) out vec2 out_accumulated_weight_and_depth;
 
 ///////////////////////////////////////////////////////////////////////////////
 // splatting methods
@@ -82,11 +83,12 @@ void main() {
   @material_input@
   @material_method_calls_frag@
 
-  out_accumulated_color = vec4(weight * gua_color, weight);
+  out_accumulated_color = vec3(weight * gua_color);
   //out_accumulated_normal = vec4(weight * face_forward_normal, gl_FragCoord.z);
-  out_accumulated_normal = vec4(weight * face_forward_normal, weight * pass_log_depth);
+  out_accumulated_normal = vec3(weight * face_forward_normal);
   out_accumulated_pbr = vec3(gua_metalness, gua_roughness, gua_emissivity) * weight;
 
+  out_accumulated_weight_and_depth = vec2(weight, weight * pass_log_depth);
 
 }
 

--- a/plugins/guacamole-plod/resources/shaders/gbuffer/plod/p03_normalization.frag
+++ b/plugins/guacamole-plod/resources/shaders/gbuffer/plod/p03_normalization.frag
@@ -26,54 +26,179 @@ layout(binding=3) uniform sampler2D p02_weight_and_depth_texture;
 // main
 ///////////////////////////////////////////////////////////////////////////////
 void main() {
-  vec3  normalized_color  = vec3(1.0);
-  float output_depth  = 1.0;
-  vec3  output_normal = vec3(0.0);
-  vec3 coords = vec3(plod_quad_coords, 0.0);
-  vec3 accumulated_color = texture(p02_color_texture, coords.xy).rgb;
- 
-  vec2 accumulated_weight_and_depth = texture(p02_weight_and_depth_texture, coords.xy).rg;
+
+  ivec2 current_fragment_pos = ivec2(gl_FragCoord.xy);
+
+  vec2 accumulated_weight_and_depth = texelFetch(p02_weight_and_depth_texture, current_fragment_pos, 0).rg;
   float accumulated_weight = accumulated_weight_and_depth.x;
 
   if(accumulated_weight == 0.0) {
-    discard;
+    //discard;
+
+    vec2 neighbour_weights_and_depth[8]; 
+
+    int bit_pattern = (0x0);
+
+    int cell_counter = 0;
+
+    for( int y = -1; y <= 1; ++y ) {
+      for( int x = -1; x <= 1; ++x ) {
+        if(x == 0 && y == 0)
+          continue;
+        float current_accumulated_neighbour_weight = 0.0;
+        ivec2 array_index_xy = ivec2(x+1, 
+                                     y+1);
+
+        neighbour_weights_and_depth[cell_counter] = texelFetch(p02_weight_and_depth_texture, current_fragment_pos + array_index_xy,0 ).rg;
+        current_accumulated_neighbour_weight = neighbour_weights_and_depth[cell_counter].r;
+
+        if(current_accumulated_neighbour_weight != 0.0) {
+          bit_pattern |= (1 << cell_counter++);
+        }
+      }
+    }
+
+    if(  ( (bit_pattern & 0xD6) == 0xD6) 
+      || ( (bit_pattern & 0xF8) == 0xF8) 
+      //|| ( (bit_pattern & 0x6B) == 0x6B)
+      //|| ( (bit_pattern & 0x1F) == 0x1F)
+      || ( (bit_pattern & 0x97) == 0x97)
+      || ( (bit_pattern & 0xF4) == 0xF4)
+      || ( (bit_pattern & 0xE9) == 0xE9)
+      //|| ( (bit_pattern & 0x2F) == 0x2F)
+      )
+    {
+    unsigned int num_accumulated_neighbours = 0;
+    vec3 final_neighbours_color  = vec3(0.0, 0.0, 0.0);
+    vec3 final_neighbours_normal = vec3(0.0, 0.0, 0.0);
+    vec3 final_neighbours_pbr    = vec3(0.0, 0.0, 0.0);
+    float final_neighbours_depth = 0.0;
+
+
+    for(int bit_index = 0; bit_index < 8; ++bit_index) {
+      if( (bit_pattern & (1 << bit_index) ) != 0x0 ) {
+        ivec2 lookup_index_xy =  ivec2(0,0);//( (bit_index % 3) - 1, 
+                                            //(bit_index / 3) - 1);
+
+        if(bit_index == 0) {
+          lookup_index_xy = ivec2(-1,-1);
+        } else if (bit_index == 1) {
+           lookup_index_xy = ivec2(0,-1);         
+        } else if (bit_index == 2) {
+           lookup_index_xy = ivec2(1,-1);
+        } else if (bit_index == 3) {
+           lookup_index_xy = ivec2( -1,0);         
+        } else if (bit_index == 4) {
+           lookup_index_xy = ivec2( 1, 0);   
+        } else if (bit_index == 5) {
+           lookup_index_xy = ivec2(-1, 1);         
+        } else if (bit_index == 6) {
+           lookup_index_xy = ivec2(0,1);   
+        } else if (bit_index == 7) {
+           lookup_index_xy = ivec2(1,1);   
+        }
+
+        ++num_accumulated_neighbours;
+
+        vec2 current_neighbours_weight_and_depth = texelFetch(p02_weight_and_depth_texture, current_fragment_pos + lookup_index_xy,0 ).rg;
+
+        if(current_neighbours_weight_and_depth.x != 0.0) {
+        final_neighbours_color  +=  (texelFetch(p02_color_texture, current_fragment_pos + lookup_index_xy,0 ).rgb) / current_neighbours_weight_and_depth.x;
+        final_neighbours_normal +=  (texelFetch(p02_normal_texture, current_fragment_pos + lookup_index_xy,0 ).xyz) /  current_neighbours_weight_and_depth.x;
+        final_neighbours_pbr    +=  (texelFetch(p02_pbr_texture, current_fragment_pos + lookup_index_xy,0 ).rgb) / current_neighbours_weight_and_depth.x;
+        final_neighbours_depth  +=   current_neighbours_weight_and_depth.y / current_neighbours_weight_and_depth.x;
+        } else {
+         final_neighbours_color  +=  vec3(1.0, 0.0, 0.0);   
+         num_accumulated_neighbours = 1;       
+        }
+      }
+
+    }
+
+
+    final_neighbours_color  /= num_accumulated_neighbours;
+    final_neighbours_normal /= num_accumulated_neighbours;
+    final_neighbours_pbr    /= num_accumulated_neighbours;
+    final_neighbours_depth  /= num_accumulated_neighbours;
+ 
+
+
+    gua_color  = final_neighbours_color;
+    gua_normal = final_neighbours_normal;
+    gua_metalness  = final_neighbours_pbr.r;
+    gua_roughness  = final_neighbours_pbr.g;
+    gua_emissivity = final_neighbours_pbr.b;
+    gua_alpha      = 1.0;
+    gua_flags_passthrough = (gua_emissivity > 0.99999);
+
+    gl_FragDepth = final_neighbours_depth;
+
+    //gua_color  = vec3(1.0,0.0,0.0);
+    /*gua_normal = vec3(0.0, 0.0, 1.0);
+    gua_metalness  = 1.0;
+    gua_roughness  = 1.0;
+    gua_emissivity = 1.0;
+    gua_alpha      = 1.0;
+    gua_flags_passthrough = (gua_emissivity > 0.99999);
+
+    gl_FragDepth = 0.5;
+    */
+    } else {
+      discard;
+    }
+
+
+
+  } else {
+
+    float accumulated_depth =  accumulated_weight_and_depth.y ;
+    float blended_depth = accumulated_depth / accumulated_weight;
+
+    vec3  normalized_color  = vec3(1.0);
+    float output_depth  = 1.0;
+    vec3  output_normal = vec3(0.0);
+    vec3 coords = vec3(plod_quad_coords, 0.0);
+    //vec3 accumulated_color = texture(p02_color_texture, coords.xy).rgb;
+    vec3 accumulated_color = texelFetch(p02_color_texture, current_fragment_pos, 0).rgb;
+   
+
+    normalized_color = accumulated_color.rgb / accumulated_weight ;
+    //normalized_color = accumulated_color.rgb;
+    normalized_color = pow(normalized_color, vec3(1.4));
+   
+    vec3 accumulated_normal = texelFetch(p02_normal_texture, current_fragment_pos, 0).rgb;
+    vec3 normalized_normal = normalize(accumulated_normal.rgb / accumulated_weight);
+
+
+    //float depth_visibility_pass = texture2D( p01_log_depth_texture, coords.xy).r;
+
+    gua_color = normalized_color.rgb;
+    gua_normal = normalized_normal;
+
+    vec3 written_pbr_coeffs = (texelFetch(p02_pbr_texture, current_fragment_pos, 0).rgb) / accumulated_weight;
+
+    gua_metalness  = written_pbr_coeffs.r;
+    gua_roughness  = written_pbr_coeffs.g;
+    gua_emissivity = written_pbr_coeffs.b;
+    gua_alpha      = 1.0;
+    gua_flags_passthrough = (gua_emissivity > 0.99999);
+
+    // calculate world position from blended depth
+    //vec4 world_pos_h = gua_inverse_projection_view_matrix * vec4(gl_FragCoord.xy, depth_visibility_pass, 1.0);
+
+    if( !(blended_depth >= 0.0 && blended_depth  <= 0.9999999) )
+      blended_depth = 0.0;
+
+    vec4 world_pos_h = gua_inverse_projection_view_matrix * vec4(gl_FragCoord.xy, blended_depth, 1.0);
+    gua_world_position = world_pos_h.xyz/world_pos_h.w;
+
+
+    gl_FragDepth = blended_depth; 
   }
 
-  normalized_color = accumulated_color.rgb / accumulated_weight ;
-  //normalized_color = accumulated_color.rgb;
-  normalized_color = pow(normalized_color, vec3(1.4));
- 
-  vec3 accumulated_normal = texture(p02_normal_texture, coords.xy).rgb;
-  float accumulated_depth =  accumulated_weight_and_depth.y ;
-  vec3 normalized_normal = normalize(accumulated_normal.rgb / accumulated_weight);
+    @include "common/gua_write_gbuffer.glsl"
 
-  float blended_depth = accumulated_depth / accumulated_weight;
-  //float depth_visibility_pass = texture2D( p01_log_depth_texture, coords.xy).r;
 
-  gua_color = normalized_color.rgb;
-  gua_normal = normalized_normal;
 
-  vec3 written_pbr_coeffs = (texture(p02_pbr_texture, coords.xy).rgb) / accumulated_weight;
-
-  gua_metalness  = written_pbr_coeffs.r;
-  gua_roughness  = written_pbr_coeffs.g;
-  gua_emissivity = written_pbr_coeffs.b;
-  gua_alpha      = 1.0;
-  gua_flags_passthrough = (gua_emissivity > 0.99999);
-
-  // calculate world position from blended depth
-  //vec4 world_pos_h = gua_inverse_projection_view_matrix * vec4(gl_FragCoord.xy, depth_visibility_pass, 1.0);
-
-  if( !(blended_depth >= 0.0 && blended_depth  <= 0.9999999) )
-    blended_depth = 0.0;
-
-  vec4 world_pos_h = gua_inverse_projection_view_matrix * vec4(gl_FragCoord.xy, blended_depth, 1.0);
-  gua_world_position = world_pos_h.xyz/world_pos_h.w;
-
-  // write correct depth instead of shifted depth
-  @include "common/gua_write_gbuffer.glsl"
-
-  gl_FragDepth = blended_depth;
-  //gl_FragDepth = 0.0;
 }
 

--- a/plugins/guacamole-plod/resources/shaders/gbuffer/plod/p03_normalization.frag
+++ b/plugins/guacamole-plod/resources/shaders/gbuffer/plod/p03_normalization.frag
@@ -11,11 +11,10 @@ in vec2 plod_quad_coords;
 @include "common/gua_camera_uniforms.glsl"
 @include "common/gua_global_variable_declaration.glsl"
 ///////////////////////////////////////////////////////////////////////////////
-//layout(binding=0) uniform sampler2D p01_depth_texture;
 layout(binding=0) uniform sampler2D p02_color_texture;
 layout(binding=1) uniform sampler2D p02_normal_texture;
 layout(binding=2) uniform sampler2D p02_pbr_texture;
-//layout(binding=3) uniform sampler2D p01_log_depth_texture;
+layout(binding=3) uniform sampler2D p02_weight_and_depth_texture;
 
 ///////////////////////////////////////////////////////////////////////////////
 // output
@@ -31,9 +30,10 @@ void main() {
   float output_depth  = 1.0;
   vec3  output_normal = vec3(0.0);
   vec3 coords = vec3(plod_quad_coords, 0.0);
-  vec4 accumulated_color = texture(p02_color_texture, coords.xy);
+  vec3 accumulated_color = texture(p02_color_texture, coords.xy).rgb;
  
-  float accumulated_weight = accumulated_color.a;
+  vec2 accumulated_weight_and_depth = texture(p02_weight_and_depth_texture, coords.xy).rg;
+  float accumulated_weight = accumulated_weight_and_depth.x;
 
   if(accumulated_weight == 0.0) {
     discard;
@@ -44,7 +44,7 @@ void main() {
   normalized_color = pow(normalized_color, vec3(1.4));
  
   vec3 accumulated_normal = texture(p02_normal_texture, coords.xy).rgb;
-  float accumulated_depth =  texture(p02_normal_texture, coords.xy).a;
+  float accumulated_depth =  accumulated_weight_and_depth.y ;
   vec3 normalized_normal = normalize(accumulated_normal.rgb / accumulated_weight);
 
   float blended_depth = accumulated_depth / accumulated_weight;

--- a/plugins/guacamole-plod/src/gua/renderer/PLODPass.cpp
+++ b/plugins/guacamole-plod/src/gua/renderer/PLODPass.cpp
@@ -47,6 +47,7 @@ PLODPassDescription::PLODPassDescription()
 {
   needs_color_buffer_as_input_ = false;
   writes_only_color_buffer_ = false;
+  enable_for_shadows_ = true;
   rendermode_ = RenderMode::Custom;
 }
 
@@ -66,8 +67,8 @@ PipelinePass PLODPassDescription::make_pass(RenderContext const& ctx, Substituti
   renderer->set_global_substitution_map(substitution_map);
 
   pass.process_ = [renderer](
-    PipelinePass& pass, PipelinePassDescription const& desc, Pipeline & pipe, bool) {
-    renderer->render(pipe, desc);
+    PipelinePass& pass, PipelinePassDescription const& desc, Pipeline & pipe, bool rendering_shadows) {
+    renderer->render(pipe, desc, rendering_shadows);
   };
 
   return pass;

--- a/plugins/guacamole-plod/src/gua/renderer/PLODRenderer.cpp
+++ b/plugins/guacamole-plod/src/gua/renderer/PLODRenderer.cpp
@@ -322,7 +322,7 @@ namespace gua {
   }
 
   ///////////////////////////////////////////////////////////////////////////////
-  void PLODRenderer::render(gua::Pipeline& pipe, PipelinePassDescription const& desc) {
+  void PLODRenderer::render(gua::Pipeline& pipe, PipelinePassDescription const& desc, bool rendering_shadows) {
 
     RenderContext const& ctx(pipe.get_context());
     

--- a/plugins/guacamole-plod/src/gua/renderer/PLODRenderer.cpp
+++ b/plugins/guacamole-plod/src/gua/renderer/PLODRenderer.cpp
@@ -185,17 +185,22 @@ namespace gua {
           
     accumulation_pass_color_result_ = ctx.render_device
       ->create_texture_2d(render_target_dims,
-                          scm::gl::FORMAT_RGBA_32F,
+                          scm::gl::FORMAT_RGB_16F,
                           1, 1, 1);
 
     accumulation_pass_normal_result_ = ctx.render_device
       ->create_texture_2d(render_target_dims,
-                          scm::gl::FORMAT_RGBA_32F,
+                          scm::gl::FORMAT_RGB_16F,
                           1, 1, 1);
 
     accumulation_pass_pbr_result_ = ctx.render_device
       ->create_texture_2d(render_target_dims,
                           scm::gl::FORMAT_RGB_16F,
+                          1, 1, 1);
+
+    accumulation_pass_weight_and_depth_result_ = ctx.render_device
+      ->create_texture_2d(render_target_dims,
+                          scm::gl::FORMAT_RG_32F,
                           1, 1, 1);
 
     log_to_lin_gua_depth_conversion_pass_fbo_ = ctx.render_device->create_frame_buffer();
@@ -218,6 +223,8 @@ namespace gua {
                                                        accumulation_pass_normal_result_);
     accumulation_pass_result_fbo_->attach_color_buffer(2,
                                                        accumulation_pass_pbr_result_);
+    accumulation_pass_result_fbo_->attach_color_buffer(3,
+                                                       accumulation_pass_weight_and_depth_result_);
     //accumulation_pass_result_fbo_->attach_depth_stencil_buffer(depth_pass_log_depth_result_);
     accumulation_pass_result_fbo_->attach_depth_stencil_buffer(depth_pass_linear_depth_result_);
 
@@ -358,16 +365,22 @@ namespace gua {
     ctx.render_context
       ->clear_color_buffer(accumulation_pass_result_fbo_,
       0,
-      scm::math::vec4f(0.0f, 0.0f, 0.0f, 0.0f));
+      scm::math::vec3f(0.0f, 0.0f, 0.0f));
+
     ctx.render_context
       ->clear_color_buffer(accumulation_pass_result_fbo_,
       1,
-      scm::math::vec4f(0.0f, 0.0f, 0.0f, 0.0f));
+      scm::math::vec3f(0.0f, 0.0f, 0.0f));
 
     ctx.render_context
       ->clear_color_buffer(accumulation_pass_result_fbo_,
       2,
-      scm::math::vec4f(0.0f, 0.0f, 0.0f));
+      scm::math::vec3f(0.0f, 0.0f, 0.0f));
+
+    ctx.render_context
+      ->clear_color_buffer(accumulation_pass_result_fbo_,
+      3,
+      scm::math::vec2f(0.0f, 0.0f));
 
     ///////////////////////////////////////////////////////////////////////////
     // program initialization
@@ -675,6 +688,9 @@ namespace gua {
 
          ctx.render_context->bind_texture(accumulation_pass_pbr_result_, nearest_sampler_state_, 2);
          normalization_pass_program_->apply_uniform(ctx, "p02_pbr_texture", 2);
+
+         ctx.render_context->bind_texture(accumulation_pass_weight_and_depth_result_, nearest_sampler_state_, 3);
+         normalization_pass_program_->apply_uniform(ctx, "p02_weight_and_depth_texture", 3);
 
          //ctx.render_context->bind_texture(depth_pass_log_depth_result_, nearest_sampler_state_, 3);
          //current_material_program->apply_uniform(ctx, "p01_log_depth_texture", 3);


### PR DESCRIPTION
-separated attributes, which need high precision (accumulated weight and depth = 2x 32 bit) from attributes which are sufficiently handled by half precision (normals & colors = 2x3x16 bit)
-add screen space reconstruction in normalization pass (definable in the shader)
-prepare shadow flags (still need unique light ID in oder to create correct shadow mode of PLOD) 