### PR TITLE
Make OculusWindow/ViveWindow interfaces identical

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -73,6 +73,11 @@ IF (GUACAMOLE_EXAMPLES)
     add_subdirectory(oculus_pitoti)
   ENDIF (${PLUGIN_guacamole-oculus} AND ${PLUGIN_guacamole-plod})
 
+  # vive example requires vive-plugin
+  IF (${PLUGIN_guacamole-vive})
+    add_subdirectory(vive)
+  ENDIF (${PLUGIN_guacamole-vive})
+
   # plod example requires plod-plugin
   IF (${PLUGIN_guacamole-plod})
     add_subdirectory(plod_simple)

--- a/examples/oculus/main.cpp
+++ b/examples/oculus/main.cpp
@@ -255,7 +255,7 @@ int main(int argc, char** argv) {
     time += frame_time;
     timer.reset();
 
-    camera->set_transform(window->get_oculus_sensor_orientation());
+    camera->set_transform(window->get_hmd_sensor_orientation());
 
     if (pipeline_use_ssao != camera->get_pipeline_description()->get_resolve_pass()->ssao_enable()) {
       camera->get_pipeline_description()->get_resolve_pass()->ssao_intensity(pipeline_ssao_intensity);

--- a/examples/vive/main.cpp
+++ b/examples/vive/main.cpp
@@ -252,7 +252,7 @@ int main(int argc, char** argv) {
         time += frame_time;
         timer.reset();
 
-        camera->set_transform(window->get_vive_sensor_orientation());
+        camera->set_transform(window->get_hmd_sensor_orientation());
 
         if (pipeline_use_ssao != camera->get_pipeline_description()->get_resolve_pass()->ssao_enable()) {
             camera->get_pipeline_description()->get_resolve_pass()->ssao_intensity(pipeline_ssao_intensity);

--- a/plugins/guacamole-oculus/include/gua/OculusWindow.hpp
+++ b/plugins/guacamole-oculus/include/gua/OculusWindow.hpp
@@ -23,19 +23,19 @@
 #define GUA_OCULUS_WINDOW_HPP
 
 #if defined (_MSC_VER)
-  #if defined (GUA_OCULUS_LIBRARY)
-    #define GUA_OCULUS_DLL __declspec( dllexport )
-  #else
+    #if defined (GUA_OCULUS_LIBRARY)
+        #define GUA_OCULUS_DLL __declspec( dllexport )
+    #else
 #define GUA_OCULUS_DLL __declspec( dllimport )
-  #endif
+    #endif
 #else
-  #define GUA_OCULUS_DLL
+    #define GUA_OCULUS_DLL
 #endif // #if defined(_MSC_VER)
 
 // guacamole headers
 #include <gua/renderer/GlfwWindow.hpp>
 
-//for the OVR members
+//for the Oculus SDK members
 #if defined (_WIN32)
     #include <OVR_CAPI.h>
     #include <Extras/OVR_Math.h>
@@ -51,49 +51,48 @@ namespace gua {
 class GUA_OCULUS_DLL OculusWindow : public GlfwWindow {
  public:
 
-  OculusWindow(std::string const& display);
-  virtual ~OculusWindow();
+    OculusWindow(std::string const& display);
+    virtual ~OculusWindow();
 
-  void open() override;
-  void init_context() override;
+    float const get_IPD() const;
+    math::vec2ui get_window_resolution() const;
+    math::vec2 const get_left_screen_size() const;
+    math::vec2 const get_right_screen_size() const;
+    math::vec3 const get_left_screen_translation() const;
+    math::vec3 const get_right_screen_translation() const;
+    
+    
+    void display(std::shared_ptr<Texture> const& texture, bool is_left);
 
-  void recenter();
+    void start_frame() override;
+    void finish_frame() override;
 
-  // virtual
-  void display(std::shared_ptr<Texture> const& texture, bool is_left);
+    void recenter();
+    void open() override;
+    void init_context() override;
+    math::mat4 get_hmd_sensor_orientation() const;
 
-  math::vec2 const get_left_screen_size() const;
-  math::vec2 const get_right_screen_size() const;
-  math::vec3 const get_left_screen_translation() const;
-  math::vec3 const get_right_screen_translation() const;
-  float const get_IPD() const;
-  
-  math::vec2ui get_window_resolution() const;
-  math::mat4 get_oculus_sensor_orientation() const;
+ private:
 
-  void start_frame() override;
-  void finish_frame() override;
-
-  private:
-
-    void initialize_oculus_environment();
-    void shutdown_oculus_environment();
+    void initialize_hmd_environment();
     void calculate_viewing_setup();
+
+
+math::vec2 screen_size_[2];
+    math::vec3 screen_translation_[2];
+
+    math::mat4 hmd_sensor_orientation_;
+    
+    unsigned int blit_fbo_read_;
+    unsigned int blit_fbo_write_;
 
     std::string display_name_;
 
-    math::vec2 screen_size_[2];
-    math::vec3 screen_translation_[2];
-
-    math::mat4 oculus_sensor_orientation_;
-
     ovrTextureSwapChain        texture_swap_chain_ = 0;
     ovrTextureSwapChainDesc    texture_swap_chain_desc_ = {};
-                      
+                                        
     ovrLayerEyeFov             color_layer_;
 
-    unsigned int               blit_fbo_read_;
-    unsigned int               blit_fbo_write_;
 
     ovrHmdDesc                 hmd_desc_;
     ovrSession                 hmd_session_;

--- a/plugins/guacamole-oculus/src/gua/OculusWindow.cpp
+++ b/plugins/guacamole-oculus/src/gua/OculusWindow.cpp
@@ -37,7 +37,7 @@ OculusWindow::OculusWindow(std::string const& display)
     display_name_(display)
 {
   // initialize hmd and texture sizes
-  initialize_oculus_environment();
+  initialize_hmd_environment();
 
   // calculate screen size, translation and eye distance
   calculate_viewing_setup();
@@ -189,8 +189,8 @@ math::vec2ui OculusWindow::get_window_resolution() const {
 }
 
 
-gua::math::mat4 OculusWindow::get_oculus_sensor_orientation() const {
-  return oculus_sensor_orientation_;
+gua::math::mat4 OculusWindow::get_hmd_sensor_orientation() const {
+  return hmd_sensor_orientation_;
 }
 
 
@@ -222,7 +222,7 @@ void OculusWindow::start_frame() {
           pose.Orientation.y,
           pose.Orientation.z);
 
-      oculus_sensor_orientation_ = scm::math::make_translation((double)pose.Position.x, (double)pose.Position.y, (double)pose.Position.z) * rot_quat.to_matrix();
+      hmd_sensor_orientation_ = scm::math::make_translation((double)pose.Position.x, (double)pose.Position.y, (double)pose.Position.z) * rot_quat.to_matrix();
     }
 }
 
@@ -241,7 +241,7 @@ void OculusWindow::finish_frame() {
 }
 
 
-void OculusWindow::initialize_oculus_environment() 
+void OculusWindow::initialize_hmd_environment() 
 {
   try {
 
@@ -323,24 +323,24 @@ void OculusWindow::calculate_viewing_setup() {
   for (unsigned eye_num = 0; eye_num < 2; ++eye_num) {
     //retreive the correct projection matrix from the oculus API
 
-      auto const& oculus_eye_projection
+      auto const& hmd_eye_projection
         = ovrMatrix4f_Projection(hmd_desc_.DefaultEyeFov[eye_num], near_distance, far_distance, 0);
 
     //convert the matrix to a gua compatible one
     scm::math::mat4 scm_eye_proj_matrix;
     for( int outer = 0; outer < 4; ++outer ) {
       for( int inner = 0; inner < 4; ++inner ){
-        scm_eye_proj_matrix[outer*4 + inner] = oculus_eye_projection.M[outer][inner];
+        scm_eye_proj_matrix[outer*4 + inner] = hmd_eye_projection.M[outer][inner];
       }
     }
 
     // unproject one frustum corner defining one clipping plane
-    scm::math::mat4 inv_oculus_eye_proj_matrix 
+    scm::math::mat4 inv_hmd_eye_proj_matrix 
       = scm::math::inverse(scm_eye_proj_matrix);
     scm::math::vec4 back_right_top_frustum_corner 
-      = scm::math::vec4(-1.0, -1.0, -1.0,  1.0) * inv_oculus_eye_proj_matrix;
+      = scm::math::vec4(-1.0, -1.0, -1.0,  1.0) * inv_hmd_eye_proj_matrix;
     scm::math::vec4 back_left_bottom_frustum_corner 
-      = scm::math::vec4( 1.0,  1.0, -1.0,  1.0) * inv_oculus_eye_proj_matrix;
+      = scm::math::vec4( 1.0,  1.0, -1.0,  1.0) * inv_hmd_eye_proj_matrix;
 
     scm::math::vec4 normalized_back_left_bottom_frustum_corner
       = back_left_bottom_frustum_corner / back_left_bottom_frustum_corner[3];

--- a/plugins/guacamole-vive/include/gua/ViveWindow.hpp
+++ b/plugins/guacamole-vive/include/gua/ViveWindow.hpp
@@ -48,9 +48,10 @@ class GUA_VIVE_DLL ViveWindow : public GlfwWindow {
 
     ViveWindow(std::string const& display);
     virtual ~ViveWindow();
+
     float const get_IPD() const;
     math::vec2ui get_window_resolution() const;
-    math::mat4 const& get_vive_sensor_orientation() const;
+    math::mat4 const& get_hmd_sensor_orientation() const; 
     math::vec2 const& get_left_screen_size() const;
     math::vec2 const& get_right_screen_size() const;
     math::vec3 const& get_left_screen_translation() const;
@@ -63,15 +64,15 @@ class GUA_VIVE_DLL ViveWindow : public GlfwWindow {
 
  private:
 
-    void initialize_vive_environment();
+    void initialize_hmd_environment();
     void calculate_viewing_setup();
     void init_context();
     void open();
 
-    math::vec2 screen_size_[2]; // in meters?
-    math::vec3 screen_translation_[2]; // in meters?
+    math::vec2 screen_size_[2];
+    math::vec3 screen_translation_[2];
 
-    math::mat4 vive_sensor_orientation_;
+    math::mat4 hmd_sensor_orientation_;
 
     // GL Frame Buffers
     unsigned int blit_fbo_read_;
@@ -88,6 +89,6 @@ class GUA_VIVE_DLL ViveWindow : public GlfwWindow {
     scm::gl::texture_2d_ptr right_texture_ = nullptr;
 };
 
-}  // namespace gua
+}
 
 #endif  // GUA_VIVE_WINDOW_HPP

--- a/plugins/guacamole-vive/src/gua/ViveWindow.cpp
+++ b/plugins/guacamole-vive/src/gua/ViveWindow.cpp
@@ -35,7 +35,7 @@ ViveWindow::ViveWindow(std::string const& display)
     , display_name_(display)
 {
     // initialize hmd and texture sizes
-    initialize_vive_environment();
+    initialize_hmd_environment();
 
     // calculate screen size, translation and eye distance
     calculate_viewing_setup();
@@ -45,7 +45,7 @@ ViveWindow::~ViveWindow() {
     vr::VR_Shutdown();
 }
 
-void ViveWindow::initialize_vive_environment() {
+void ViveWindow::initialize_hmd_environment() {
     vr::EVRInitError eError = vr::VRInitError_None;
     pVRSystem = vr::VR_Init(&eError, vr::VRApplication_Scene);
 
@@ -85,8 +85,8 @@ void ViveWindow::calculate_viewing_setup() {
     // do the viewing setup calculations for both eyes
     for (unsigned eye_num = 0; eye_num < 2; ++eye_num) {
         vr::EVREye eEye = eye_num == 0 ? vr::EVREye::Eye_Left : vr::EVREye::Eye_Right;
-        //retreive the correct projection matrix from the oculus API
-        auto const& vive_eye_projection = pVRSystem->GetProjectionMatrix(
+        //retreive the correct projection matrix from OpenVR
+        auto const& hmd_eye_projection = pVRSystem->GetProjectionMatrix(
             eEye, near_distance, far_distance, vr::EGraphicsAPIConvention::API_OpenGL
         );
 
@@ -94,16 +94,16 @@ void ViveWindow::calculate_viewing_setup() {
         scm::math::mat4 scm_eye_proj_matrix;
         for (int outer = 0; outer < 4; ++outer) {
             for (int inner = 0; inner < 4; ++inner) {
-                scm_eye_proj_matrix[outer*4 + inner] = vive_eye_projection.m[outer][inner];
+                scm_eye_proj_matrix[outer*4 + inner] = hmd_eye_projection.m[outer][inner];
             }
         }
 
         // unproject one frustum corner defining one clipping plane
-        scm::math::mat4 inv_oculus_eye_proj_matrix = scm::math::inverse(scm_eye_proj_matrix);
+        scm::math::mat4 inv_hmd_eye_proj_matrix = scm::math::inverse(scm_eye_proj_matrix);
         scm::math::vec4 back_right_top_frustum_corner = scm::math::vec4(-1.0, -1.0, -1.0,  1.0) *
-            inv_oculus_eye_proj_matrix;
+            inv_hmd_eye_proj_matrix;
         scm::math::vec4 back_left_bottom_frustum_corner = scm::math::vec4(1.0,  1.0, -1.0,  1.0) *
-            inv_oculus_eye_proj_matrix;
+            inv_hmd_eye_proj_matrix;
 
         scm::math::vec4 normalized_back_left_bottom_frustum_corner =
             back_left_bottom_frustum_corner / back_left_bottom_frustum_corner[3];
@@ -199,7 +199,6 @@ void ViveWindow::init_context() {
 }
 
 void ViveWindow::open() {
-    // open side-by-side debug window which shows exactly the same as oculus
     config.set_title("guacamole");
     config.set_display_name(display_name_);
     config.set_stereo_mode(StereoMode::SIDE_BY_SIDE);
@@ -213,8 +212,8 @@ math::vec2ui ViveWindow::get_window_resolution() const {
     return math::vec2ui(width, height);
 }
 
-math::mat4 const& ViveWindow::get_vive_sensor_orientation() const {
-    return vive_sensor_orientation_;
+math::mat4 const& ViveWindow::get_hmd_sensor_orientation() const {
+    return hmd_sensor_orientation_;
 }
 
 math::vec2 const& ViveWindow::get_left_screen_size() const {
@@ -262,7 +261,7 @@ void ViveWindow::start_frame() {
         pose.m[0][2], pose.m[1][2], pose.m[2][2], 0.0,
         pose.m[0][3], pose.m[1][3], pose.m[2][3], 1.0
     );
-    vive_sensor_orientation_ = orientation;
+    hmd_sensor_orientation_ = orientation;
 }
 
 void ViveWindow::finish_frame() {


### PR DESCRIPTION
There were a few method and variable names in both implementations referring to the devices (e.g. `oculus` and `vive`). I streamlined that so that both windows refer to `hmd` instead.