### PR TITLE
Fix public/private method mismatch in Oculus and ViveWindow

### DIFF
--- a/plugins/guacamole-oculus/include/gua/OculusWindow.hpp
+++ b/plugins/guacamole-oculus/include/gua/OculusWindow.hpp
@@ -56,48 +56,44 @@ class GUA_OCULUS_DLL OculusWindow : public GlfwWindow {
 
     float const get_IPD() const;
     math::vec2ui get_window_resolution() const;
-    math::vec2 const get_left_screen_size() const;
-    math::vec2 const get_right_screen_size() const;
-    math::vec3 const get_left_screen_translation() const;
-    math::vec3 const get_right_screen_translation() const;
-    
-    
+    math::mat4 const& get_hmd_sensor_orientation() const;
+
+    math::vec2 const& get_left_screen_size() const;
+    math::vec2 const& get_right_screen_size() const;
+    math::vec3 const& get_left_screen_translation() const;
+    math::vec3 const& get_right_screen_translation() const;
+
     void display(std::shared_ptr<Texture> const& texture, bool is_left);
 
+    void open() override;
+    void init_context() override;
     void start_frame() override;
     void finish_frame() override;
 
     void recenter();
-    void open() override;
-    void init_context() override;
-    math::mat4 get_hmd_sensor_orientation() const;
 
  private:
 
     void initialize_hmd_environment();
     void calculate_viewing_setup();
 
+    std::string display_name_;
+    math::mat4 hmd_sensor_orientation_;
 
-math::vec2 screen_size_[2];
+    math::vec2 screen_size_[2];
     math::vec3 screen_translation_[2];
 
-    math::mat4 hmd_sensor_orientation_;
-    
     unsigned int blit_fbo_read_;
     unsigned int blit_fbo_write_;
 
-    std::string display_name_;
+    ovrTextureSwapChain texture_swap_chain_ = 0;
+    ovrTextureSwapChainDesc texture_swap_chain_desc_ = {};
 
-    ovrTextureSwapChain        texture_swap_chain_ = 0;
-    ovrTextureSwapChainDesc    texture_swap_chain_desc_ = {};
-                                        
-    ovrLayerEyeFov             color_layer_;
+    ovrLayerEyeFov color_layer_;
 
-
-    ovrHmdDesc                 hmd_desc_;
-    ovrSession                 hmd_session_;
-    unsigned                   framecount_ = 0;
-
+    ovrHmdDesc hmd_desc_;
+    ovrSession hmd_session_;
+    unsigned framecount_ = 0;
 
 };
 

--- a/plugins/guacamole-vive/include/gua/ViveWindow.hpp
+++ b/plugins/guacamole-vive/include/gua/ViveWindow.hpp
@@ -51,7 +51,8 @@ class GUA_VIVE_DLL ViveWindow : public GlfwWindow {
 
     float const get_IPD() const;
     math::vec2ui get_window_resolution() const;
-    math::mat4 const& get_hmd_sensor_orientation() const; 
+    math::mat4 const& get_hmd_sensor_orientation() const;
+
     math::vec2 const& get_left_screen_size() const;
     math::vec2 const& get_right_screen_size() const;
     math::vec3 const& get_left_screen_translation() const;
@@ -59,6 +60,8 @@ class GUA_VIVE_DLL ViveWindow : public GlfwWindow {
 
     void display(std::shared_ptr<Texture> const& texture, bool is_left) override;
 
+    void open() override;
+    void init_context() override;
     void start_frame() override;
     void finish_frame() override;
 
@@ -66,21 +69,17 @@ class GUA_VIVE_DLL ViveWindow : public GlfwWindow {
 
     void initialize_hmd_environment();
     void calculate_viewing_setup();
-    void init_context();
-    void open();
+
+    std::string display_name_;
+    vr::IVRSystem *pVRSystem = nullptr;
+    math::mat4 hmd_sensor_orientation_;
 
     math::vec2 screen_size_[2];
     math::vec3 screen_translation_[2];
 
-    math::mat4 hmd_sensor_orientation_;
-
     // GL Frame Buffers
     unsigned int blit_fbo_read_;
     unsigned int blit_fbo_write_;
-
-    std::string display_name_;
-
-    vr::IVRSystem *pVRSystem = nullptr;
 
     unsigned left_tex_id_ = 0;
     unsigned right_tex_id_ = 0;


### PR DESCRIPTION
In `ViveWindow`, the `open()` and `init_context()` methods were private but they are public in `OculusWindow`. The examples for Unix systems call these methods, so they need to be public.

Also I made some getters in the `OculusWindow` return per const reference instead of per value. I'm not sure about performance implications and whether it might be better to return these by value. I changed that because the `ViveWindow` returned by const reference and there was a mismatch between both classes.